### PR TITLE
ci: pin minimatch v3 and use Node 22 in CI matrix; use npm ci for deterministic install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,11 @@ jobs:
 
     - name: Build
       run: |
-        npm ci
+        if [ -f package-lock.json ]; then
+          npm ci
+        else
+          npm install
+        fi
         npx tsc
     - name: Install VSCE
       run: npm install -g vsce

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
         fi
         npx tsc
     - name: Install VSCE
+      if: matrix.node-version == '22.x'
       run: npm install -g vsce
     - name: Build VSIX
+      if: matrix.node-version == '22.x'
       run: vsce package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 21.x]
+        node-version: [18.x, 22.x]
 
     steps:
     - uses: actions/checkout@v4
@@ -24,7 +24,7 @@ jobs:
 
     - name: Build
       run: |
-        npm install
+        npm ci
         npx tsc
     - name: Install VSCE
       run: npm install -g vsce

--- a/package.json
+++ b/package.json
@@ -135,4 +135,8 @@
 		"https": "^1.0.0",
 		"iconv-lite": "^0.6.3"
 	}
+	,
+	"overrides": {
+		"minimatch": "3.1.2"
+	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI updated to include Node.js 22 (removing 21) and use lockfile-aware installs for faster, more reproducible builds.
  * Certain build/release steps are now executed only on Node.js 22 to align tooling with the newer runtime.
  * Pinned a transitive dependency via overrides to ensure consistent and reliable dependency resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->